### PR TITLE
Using scope to get options category

### DIFF
--- a/app/Http/Controllers/Admin/CategoryController.php
+++ b/app/Http/Controllers/Admin/CategoryController.php
@@ -7,7 +7,6 @@ use App\Http\Requests\Category\StoreCategoryRequest;
 use App\Http\Requests\Category\UpdateCategoryRequest;
 use App\Models\Category;
 use Illuminate\Contracts\View\View;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
@@ -39,7 +38,7 @@ class CategoryController extends Controller
     public function create(): View
     {
         return view('admin.categories.create', [
-            'categories' => $this->getOptions(),
+            'categoryOptions' => Category::query()->active()->options()->get(),
         ]);
     }
 
@@ -79,7 +78,7 @@ class CategoryController extends Controller
     {
         return view('admin.categories.edit', [
             'category' => $category,
-            'categoryOptions' => $this->getOptions(),
+            'categoryOptions' => Category::query()->active()->options()->get(),
         ]);
     }
 
@@ -130,13 +129,5 @@ class CategoryController extends Controller
 
             return back()->with('error', __('category.messages.bulk_delete_fail'));
         }
-    }
-
-    protected function getOptions(): Collection
-    {
-        return Category::query()
-            ->active()
-            ->select('id', 'name')
-            ->get();
     }
 }

--- a/app/Http/Controllers/Admin/PostController.php
+++ b/app/Http/Controllers/Admin/PostController.php
@@ -46,7 +46,7 @@ class PostController extends Controller
     public function create(): View
     {
         return view('admin.posts.create', [
-            'categories' => $this->getOptions(),
+            'options' => Category::query()->active()->options()->get(),
         ]);
     }
 
@@ -95,7 +95,7 @@ class PostController extends Controller
     {
         return view('admin.posts.edit', [
             'post' => $post,
-            'options' => $this->getOptions(),
+            'options' => Category::query()->active()->options()->get(),
         ]);
     }
 

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -53,4 +53,9 @@ class Category extends Model
             $q->whereLike('name', '%'.$search.'%');
         });
     }
+
+    public function scopeOptions(Builder $query): Builder
+    {
+        return $query->select('id', 'name');
+    }
 }

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -39,7 +39,7 @@
                                     <select name="parent_id" id="parent_id"
                                         class="mt-2 w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm">
                                         <option value="">{{ __('category.form.select_parent') }}</option>
-                                        @foreach ($categories as $category)
+                                        @foreach ($categoryOptions as $category)
                                             <option value="{{ $category->id }}"
                                                 {{ (int) old('parent_id') === $category->id ? 'selected' : '' }}>
                                                 {{ $category->name }}

--- a/resources/views/admin/posts/create.blade.php
+++ b/resources/views/admin/posts/create.blade.php
@@ -39,7 +39,7 @@
                                     <select name="category_id" id="category_id"
                                         class="mt-2 w-full border-gray-300 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-300 focus:border-indigo-500 dark:focus:border-indigo-600 focus:ring-indigo-500 dark:focus:ring-indigo-600 rounded-md shadow-sm">
                                         <option value="">{{ __('post.form.select_category') }}</option>
-                                        @foreach ($categories as $category)
+                                        @foreach ($options as $category)
                                             <option value="{{ $category->id }}" {{ (int) old('category_id') === $category->id ? 'selected' : '' }}>
                                                 {{ $category->name }}
                                             </option>


### PR DESCRIPTION
## Summary by Sourcery

Refactor category option retrieval by introducing a new scopeOptions on the Category model and replacing the redundant controller getOptions method with active()->options()->get() queries in category and post controllers, updating related views to use the new option variables.

Enhancements:
- Add scopeOptions to Category model to encapsulate the id and name selection.
- Replace getOptions method in controllers with Category::query()->active()->options()->get() and remove the redundant method.
- Update category and post form views to use the new categoryOptions and options variable names for iterating selectable categories.